### PR TITLE
Move close button to right

### DIFF
--- a/contents/ui/ClientComponent.qml
+++ b/contents/ui/ClientComponent.qml
@@ -47,7 +47,7 @@ Item {
     Item {
         id: clientDecorations
         height: desktopItem.clientsDecorationsHeight
-        width: clientThumbnail.width * 0.8
+        width: parent.width - desktopItem.clientsPadding * 2
         anchors.top: parent.top
         anchors.topMargin: desktopItem.clientsPadding
         anchors.horizontalCenter: parent.horizontalCenter
@@ -56,6 +56,7 @@ Item {
         RowLayout {
             anchors.horizontalCenter: parent.horizontalCenter
             height: parent.height
+            width: parent.width
             spacing: 10
 
             PlasmaCore.IconItem {
@@ -63,6 +64,8 @@ Item {
                 source: clientItem.client ? clientItem.client.icon : null
                 implicitHeight: parent.height
                 implicitWidth: parent.height
+                anchors.right: caption.left
+                anchors.rightMargin: 10
             }
 
             Text {
@@ -72,6 +75,7 @@ Item {
                 verticalAlignment: Text.AlignVCenter
                 elide: Text.ElideRight
                 color: "white"
+                anchors.horizontalCenter: parent.horizontalCenter
                 Layout.maximumWidth: clientDecorations.width - icon.width - parent.spacing - closeButton.width - parent.spacing
             }
 
@@ -80,6 +84,7 @@ Item {
                 id: closeButtonWrapper
                 implicitHeight: parent.height
                 implicitWidth: parent.height
+                anchors.right: parent.right
 
                 RoundButton {
                     id: closeButton


### PR DESCRIPTION
I made some changes to move the close button to right, based on the  [#53](https://github.com/tcorreabr/Parachute/issues/53) issue.

![Screenshot_20201006_125231](https://user-images.githubusercontent.com/33737137/95226019-d56ab980-07d2-11eb-96fd-4451a251c688.png)