### PR TITLE
Use KWin slots for desktop switching

### DIFF
--- a/contents/ui/WheelHandlerComponent.qml
+++ b/contents/ui/WheelHandlerComponent.qml
@@ -12,7 +12,7 @@ Item {
             if (active) return;
 
             if (wheelDelta >= 120 || wheelDelta <= -120) {
-                wheelDelta > 0 ? workspace.currentDesktop-- : workspace.currentDesktop++;
+                wheelDelta > 0 ? workspace.slotSwitchDesktopPrevious() : workspace.slotSwitchDesktopNext();
                 wheelDelta = 0;
             }
         }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -69,21 +69,21 @@ Window {
                     break;
                 case Qt.Key_Left:
                     if (event.modifiers & Qt.ShiftModifier) {
-                        workspace.currentDesktop--;
+                        workspace.slotSwitchDesktopPrevious();
                     } else {
                         selectedClientItem ? selectNextClientOn(Enums.Position.Left) : selectFirstClient();
                     }
                     break;
                 case Qt.Key_Right:
                     if (event.modifiers & Qt.ShiftModifier) {
-                        workspace.currentDesktop++;
+                        workspace.slotSwitchDesktopNext();
                     } else {
                         selectedClientItem ? selectNextClientOn(Enums.Position.Right) : selectLastClient();
                     }
                     break;
                 case Qt.Key_Up:
                     if (event.modifiers & Qt.ShiftModifier) {
-                        workspace.currentDesktop--;
+                        workspace.slotSwitchDesktopPrevious();
                     } else {
                         let tmpSelectedClientItem = selectedClientItem;
 
@@ -98,7 +98,7 @@ Window {
                     break;
                 case Qt.Key_Down:
                     if (event.modifiers & Qt.ShiftModifier) {
-                        workspace.currentDesktop++;
+                        workspace.slotSwitchDesktopNext()
                     } else {
                         selectedClientItem ? selectNextClientOn(Enums.Position.Bottom) : selectLastClient();
                     }


### PR DESCRIPTION
I just discovered Parachute and I realize this is exactly what I needed. Thanks for creating it!

However, I noticed it doesn't respect "Desktop navigation wraps around" setting. This resides in Behavior > Virtual desktops. When this setting is in effect, then switching from first desktop to previous will cause KWin to switch around to last. So you can basically only move to previous / next and will always be able to select any desktop.

By using KWin public interface for desktop switching instead of changing `currentDesktop` property, we can automatically handle this setting.

I know project is paused, but hopefully you can merge it, so at least people who installed from git can benefit from this change.